### PR TITLE
Tweak for testcase to work with v0.14 compatibile layer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
 require "bundler/gem_tasks"
+require 'rake/testtask'
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'lib' << 'test'
+  test.pattern = 'test/**/test_*.rb'
+  test.verbose = true
+end
+task :default => :test

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -69,5 +69,3 @@ def ipv6_enabled?
     false
   end
 end
-
-$log = Fluent::Log.new(Fluent::Test::DummyLogDevice.new, Fluent::Log::LEVEL_WARN)


### PR DESCRIPTION
I think that this plugin should work with Fluentd v0.14 on compatible layer.
This plugin does not depends on test-unit for development.
And I tried to remove needless dummy log device creation in test.