### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,8 @@
 require "bundler/gem_tasks"
+require 'rake/testtask'
+Rake::TestTask.new(:test) do |test|
+  test.libs << 'lib' << 'test'
+  test.pattern = 'test/**/test_*.rb'
+  test.verbose = true
+end
+task :default => :test

--- a/lib/fluent/plugin/parser_base64.rb
+++ b/lib/fluent/plugin/parser_base64.rb
@@ -1,7 +1,9 @@
+require "fluent/plugin/parser"
+
 module Fluent
-  class TextParser
+  module Plugin
     class Base64Parser < Parser
-      Plugin.register_parser("base64", self)
+      Fluent::Plugin.register_parser("base64", self)
 
       config_param :message_key, :string, :default => 'message'
       config_param :base64_encode, :bool, :default => true
@@ -19,12 +21,8 @@ module Fluent
           record[@message_key] = ::Base64.strict_decode64(text)
         end
 
-        time = @estimate_current_event ? Engine.now : nil
-        if block_given?
-          yield time, record
-        else
-          return time, record
-        end
+        time = @estimate_current_event ? Fluent::Engine.now : nil
+        yield time, record
       end
     end
   end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -69,5 +69,3 @@ def ipv6_enabled?
     false
   end
 end
-
-$log = Fluent::Log.new(Fluent::Test::DummyLogDevice.new, Fluent::Log::LEVEL_WARN)

--- a/test/plugin/test_parser_base64.rb
+++ b/test/plugin/test_parser_base64.rb
@@ -8,32 +8,24 @@ include Fluent
 
 class Base64ParserTest < ::Test::Unit::TestCase
   def test_encode
-    parser = TextParser::Base64Parser.new
+    parser = Plugin::Base64Parser.new
     parser.configure('message_key' => 'msg', 'base64_encode' => true)
 
-    # for the old, return based API
     text = 'foo'
     expected_record = {'msg' => 'Zm9v' }
-    time, record = parser.parse(text)
-    assert_equal(expected_record, record)
 
-    # for the new API
     parser.parse(text) {|time, record|
       assert_equal(expected_record, record)
     }
   end
 
   def test_decode
-    parser = TextParser::Base64Parser.new
+    parser = Plugin::Base64Parser.new
     parser.configure('message_key' => 'msg', 'base64_encode' => false)
 
-    # for the old, return based API
     text = 'Zm9v'
     expected_record = {'msg' => 'foo' }
-    time, record = parser.parse(text)
-    assert_equal(expected_record, record)
 
-    # for the new API
     parser.parse(text) {|time, record|
       assert_equal(expected_record, record)
     }


### PR DESCRIPTION
Please review after #1 is merged.

---

I've tried to migrate to use v0.14 Parser Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.