### PR TITLE
Migrate to v0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can use it wherever you used the format parameter to parse texts. In the fol
 
 ```
 <source>
-  type tail
+  @type tail
   path /path/to/log
   format base64
   base64_encode true

--- a/fluent-plugin-base64-parser.gemspec
+++ b/fluent-plugin-base64-parser.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-base64-parser"
-  spec.version       = "0.0.3"
+  spec.version       = "0.1.0"
   spec.authors       = ["nori3tsu"]
   spec.email         = ["tugend.licht@gmail.com"]
 
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency("rr", ">= 1.0.0")
   spec.add_development_dependency("test-unit-rr", "~> 1.0.3")
-  spec.add_runtime_dependency "fluentd", ">=0.10.58"
+  spec.add_runtime_dependency "fluentd", ">= 0.14.0", "< 2"
 end


### PR DESCRIPTION
In response to #2, the supported version of the plugin has been changed from v0.12.0 to v0.14.0.